### PR TITLE
support running rubudocs with mono on *nix

### DIFF
--- a/fubudocs/bin/fubudocs
+++ b/fubudocs/bin/fubudocs
@@ -1,3 +1,10 @@
 #!/usr/bin/env ruby
 
-system("#{File.dirname(__FILE__)}/fubudocs_exe/FubuDocsRunner.exe", *ARGV)
+cmd=""
+if(!RUBY_PLATFORM.match("linux|darwin").nil?)
+    cmd << "mono "
+end
+cmd << "#{File.dirname(__FILE__)}/fubudocs_exe/FubuDocsRunner.exe" + ARGV.join(' ')
+
+result = system(cmd)
+exit 1 unless result


### PR DESCRIPTION
mono-ify the fubudocs script to support running on mono.
