### PR TITLE
fix Gemfile deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rake", "~>10.0"
 gem "bundler", ">=1.3.5"


### PR DESCRIPTION
This patch gets rid of the warning that comes at the beginning of builds:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
